### PR TITLE
Use external project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,6 @@ jobs:
           echo '${{ github.workspace }}/build/boost-prefix/lib' >> $GITHUB_PATH
           echo '${{ github.workspace }}/build/opencv-prefix/bin' >> $GITHUB_PATH
           echo '${{ github.workspace }}/build/opencv-prefix/lib' >> $GITHUB_PATH
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/${{ github.workspace }}/build/boost-prefix/lib
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/${{ github.workspace }}/build/opencv-prefix/lib
 
       # Setup Python
       - name: Setup Python
@@ -59,6 +57,8 @@ jobs:
       # Run Test
       - name: Run Integration Tests
         run: |
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${{ github.workspace }}/build/boost-prefix/lib
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${{ github.workspace }}/build/opencv-prefix/lib
           echo $LD_LIBRARY_PATH
           python3 ./run.py
         working-directory: scripts/integration_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,12 @@ jobs:
         run: cmake -B ${{ github.workspace }}/build -S ${{ github.workspace }} -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
       - name: Build
         run: cmake --build ${{ github.workspace }}/build --config ${{ env.BUILD_TYPE }} --parallel $(nproc --all)
-      - name: Install
-        run: cmake --install ${{ github.workspace }}/build --config ${{ env.BUILD_TYPE }}
+      - name: Add System Paths
+        run: |
+          echo '${{ github.workspace }}/build/out/fractool' >> $GITHUB_PATH
+          echo '${{ github.workspace }}/build/boost-prefix/lib' >> $GITHUB_PATH
+          echo '${{ github.workspace }}/build/opencv-prefix/bin' >> $GITHUB_PATH
+          echo '${{ github.workspace }}/build/opencv-prefix/lib' >> $GITHUB_PATH
 
       # Setup Python
       - name: Setup Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,13 @@ jobs:
     steps:
       # Checkout code
       - uses: actions/checkout@v2
+      - run: nproc --all
 
       # Build and install using CMake
       - name: Configure
         run: cmake -B ${{ github.workspace }}/build -S ${{ github.workspace }} -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
       - name: Build
-        run: cmake --build ${{ github.workspace }}/build --config ${{ env.BUILD_TYPE }}
+        run: cmake --build ${{ github.workspace }}/build --config ${{ env.BUILD_TYPE }} --parallel $(nproc --all)
       - name: Install
         run: cmake --install ${{ github.workspace }}/build --config ${{ env.BUILD_TYPE }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,5 +58,7 @@ jobs:
 
       # Run Test
       - name: Run Integration Tests
-        run: python3 ./run.py
+        run: |
+          echo $LD_LIBRARY_PATH
+          python3 ./run.py
         working-directory: scripts/integration_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,13 @@ jobs:
         run: nproc --all
 
       # Build and install using CMake
+      - name: Cache Dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ github.workspace }}/build/boost-prefix
+            ${{ github.worksapce }}/build/opencv-prefix
+          key: dependencies
       - name: Configure
         run: cmake -B ${{ github.workspace }}/build -S ${{ github.workspace }} -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
       - name: Build
@@ -38,6 +45,8 @@ jobs:
           echo '${{ github.workspace }}/build/boost-prefix/lib' >> $GITHUB_PATH
           echo '${{ github.workspace }}/build/opencv-prefix/bin' >> $GITHUB_PATH
           echo '${{ github.workspace }}/build/opencv-prefix/lib' >> $GITHUB_PATH
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/${{ github.workspace }}/build/boost-prefix/lib
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/${{ github.workspace }}/build/opencv-prefix/lib
 
       # Setup Python
       - name: Setup Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,16 @@ env:
 
 # Jobs
 jobs:
-  buildandtest:
-    name: Build and Test
+  integration:
+    name: Integration Test
     runs-on: ubuntu-latest
     steps:
       # Checkout code
       - uses: actions/checkout@v2
-      - run: nproc --all
+
+      # Print info
+      - name: How Many Cores Do We Have?
+        run: nproc --all
 
       # Build and install using CMake
       - name: Configure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,35 +23,13 @@ jobs:
       # Checkout code
       - uses: actions/checkout@v2
 
-      # Install Dependencies
-      - name: Install Boost
-        run: |
-          wget https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.gz
-          tar -xzf boost_1_78_0.tar.gz
-          cd boost_1_78_0
-          ./bootstrap.sh --prefix=/usr/
-          ./b2
-          sudo ./b2 install
-      - name: Cache OpenCV
-        id: opencv-cache
-        uses: actions/cache@v2
-        with:
-          path: ./opencv-install
-          key: ${{ runner.os }}-opencv-cache
-      - name: Install OpenCV
-        uses: rayandrews/with-opencv-action@v1
-        with:  
-          dir: ./opencv-install
-          cached: ${{ steps.opencv-cache.outputs.cache-hit }}
-          opencv-version: '4.5.0'
-
-      # Build using CMake
-      - name: Configure CMake
+      # Build and install using CMake
+      - name: Configure
         run: cmake -B ${{ github.workspace }}/build -S ${{ github.workspace }} -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
-        env:
-          BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
       - name: Build
         run: cmake --build ${{ github.workspace }}/build --config ${{ env.BUILD_TYPE }}
+      - name: Install
+        run: cmake --install ${{ github.workspace }}/build --config ${{ env.BUILD_TYPE }}
 
       # Setup Python
       - name: Setup Python
@@ -65,5 +43,3 @@ jobs:
       - name: Run Integration Tests
         run: python3 ./run.py
         working-directory: scripts/integration_test
-        env:
-          BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(FracTool)
 set(CMAKE_CXX_STANDARD 14)
 include_directories(include)
 link_directories(/usr/local/lib)
+add_compile_options(-pthread)
 
 # External Project
 include(ExternalProject)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ set_property(
     TARGET opencv::imgcodecs 
     PROPERTY IMPORTED_LOCATION 
         ${install_dir}/lib/libopencv_imgcodecs${CMAKE_SHARED_LIBRARY_SUFFIX})
-add_dependencies(opencv::core opencv)
+add_dependencies(opencv::imgcodecs opencv)
 
 # Configure boost
 ExternalProject_Add(
@@ -46,6 +46,7 @@ ExternalProject_Add(
     BUILD_IN_SOURCE 1
 )
 ExternalProject_Get_Property(boost install_dir)
+add_definitions(-DBOOST_LOG_DYN_LINK)
 include_directories(${install_dir}/include)
 add_library(boost::log_setup SHARED IMPORTED)
 set_property(
@@ -65,13 +66,6 @@ set_property(
     PROPERTY IMPORTED_LOCATION 
         ${install_dir}/lib/libboost_program_options${CMAKE_SHARED_LIBRARY_SUFFIX})
 add_dependencies(boost::program_options boost)
-add_library(boost::thread SHARED IMPORTED)
-set_property(
-    TARGET boost::thread 
-    PROPERTY IMPORTED_LOCATION 
-        ${install_dir}/lib/libboost_thread${CMAKE_SHARED_LIBRARY_SUFFIX})
-add_dependencies(boost::thread boost)
-add_definitions(-DBOOST_LOG_DYN_LINK)
 
 # Source directory
 add_subdirectory(src out)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,12 @@ set_property(
     PROPERTY IMPORTED_LOCATION 
         ${install_dir}/lib/libboost_program_options${CMAKE_SHARED_LIBRARY_SUFFIX})
 add_dependencies(boost::program_options boost)
+add_library(boost::thread SHARED IMPORTED)
+set_property(
+    TARGET boost::thread 
+    PROPERTY IMPORTED_LOCATION 
+        ${install_dir}/lib/libboost_thread${CMAKE_SHARED_LIBRARY_SUFFIX})
+add_dependencies(boost::thread boost)
 add_definitions(-DBOOST_LOG_DYN_LINK)
 
 # Source directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,21 @@ set(CMAKE_CXX_STANDARD 14)
 include_directories(include)
 link_directories(/usr/local/lib)
 
+# External Project
+include(ExternalProject)
+ExternalProject_Add(
+    opencv4
+    GIT_REPOSITORY "https://github.com/opencv/opencv.git"
+    GIT_TAG "4.5.5"
+)
+ExternalProject_Add(
+    boost_1_78_0
+    URL "https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.gz"
+    CONFIGURE_COMMAND "./bootstrap.sh"
+    BUILD_COMMAND "./b2"
+    INSTALL_COMMAND "./b2 install"
+)
+
 # Packages
 set(Boost_USE_STATIC_LIBS ON)
 find_package(OpenCV 4.5 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_CXX_STANDARD 14)
 include_directories(include)
 link_directories(/usr/local/lib)
 add_compile_options(-pthread)
+add_link_options(-pthread)
 
 # External Project
 include(ExternalProject)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,30 +2,68 @@
 cmake_minimum_required(VERSION 3.0)
 project(FracTool)
 
-# Build config
+# Configure Project
 set(CMAKE_CXX_STANDARD 14)
 include_directories(include)
 link_directories(/usr/local/lib)
 
 # External Project
 include(ExternalProject)
+
+# Configure opencv
 ExternalProject_Add(
-    opencv4
+    opencv
     GIT_REPOSITORY "https://github.com/opencv/opencv.git"
     GIT_TAG "4.5.5"
+    CMAKE_ARGS
+        -DOPENCV_FORCE_3RDPARTY_BUILD=ON
+        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
 )
+ExternalProject_Get_Property(opencv install_dir)
+include_directories(${install_dir}/include/opencv4)
+add_library(opencv::core SHARED IMPORTED)
+set_property(
+    TARGET opencv::core 
+    PROPERTY IMPORTED_LOCATION 
+        ${install_dir}/lib/libopencv_core${CMAKE_SHARED_LIBRARY_SUFFIX})
+add_dependencies(opencv::core opencv)
+add_library(opencv::imgcodecs SHARED IMPORTED)
+set_property(
+    TARGET opencv::imgcodecs 
+    PROPERTY IMPORTED_LOCATION 
+        ${install_dir}/lib/libopencv_imgcodecs${CMAKE_SHARED_LIBRARY_SUFFIX})
+add_dependencies(opencv::core opencv)
+
+# Configure boost
 ExternalProject_Add(
-    boost_1_78_0
+    boost
     URL "https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.gz"
-    CONFIGURE_COMMAND "./bootstrap.sh"
-    BUILD_COMMAND "./b2"
-    INSTALL_COMMAND "./b2 install"
+    CONFIGURE_COMMAND <SOURCE_DIR>/bootstrap.sh
+    BUILD_COMMAND <SOURCE_DIR>/b2
+    INSTALL_COMMAND <SOURCE_DIR>/b2 install --prefix=<INSTALL_DIR>
+    BUILD_IN_SOURCE 1
 )
+ExternalProject_Get_Property(boost install_dir)
+include_directories(${install_dir}/include)
+add_library(boost::log_setup SHARED IMPORTED)
+set_property(
+    TARGET boost::log_setup 
+    PROPERTY IMPORTED_LOCATION 
+        ${install_dir}/lib/libboost_log_setup${CMAKE_SHARED_LIBRARY_SUFFIX})
+add_dependencies(boost::log_setup boost)
+add_library(boost::log SHARED IMPORTED)
+set_property(
+    TARGET boost::log 
+    PROPERTY IMPORTED_LOCATION 
+        ${install_dir}/lib/libboost_log${CMAKE_SHARED_LIBRARY_SUFFIX})
+add_dependencies(boost::log boost)
+add_library(boost::program_options SHARED IMPORTED)
+set_property(
+    TARGET boost::program_options 
+    PROPERTY IMPORTED_LOCATION 
+        ${install_dir}/lib/libboost_program_options${CMAKE_SHARED_LIBRARY_SUFFIX})
+add_dependencies(boost::program_options boost)
+add_definitions(-DBOOST_LOG_DYN_LINK)
 
-# Packages
-set(Boost_USE_STATIC_LIBS ON)
-find_package(OpenCV 4.5 REQUIRED)
-find_package(Boost 1.73 REQUIRED COMPONENTS log program_options thread)
-
-# Source directories
+# Source directory
 add_subdirectory(src out)

--- a/scripts/integration_test/run.py
+++ b/scripts/integration_test/run.py
@@ -8,7 +8,7 @@ import sys
 
 # Directory environment
 expected_rel = 'expected'
-executable_rel = '../../build/out/fractool/fractool'
+executable = 'fractool'
 
 # Help message
 help_message = b"""$ fractool [options]
@@ -26,23 +26,9 @@ def tmp_env(tmp_path):
     Create temporary environment for each integration tests
     """
     curr = os.getcwd()
-    print(curr)
-    print(os.listdir(os.path.join(curr, '../..')))
-    print(os.listdir(os.path.join(curr, '../../build')))
-    print(os.listdir(os.path.join(curr, '../../build/out')))
-    print(os.listdir(os.path.join(curr, '../../build/out/fractool')))
-    print(os.listdir(os.path.join(curr, 'expected')))
-    executable = os.path.join(curr, executable_rel)
-    print(executable)
-    print(os.stat(executable).st_mode)
-    print(os.access(executable, os.X_OK))
     expected = os.path.join(curr, expected_rel)
-    print(expected)
     os.chdir(tmp_path)
-    print(os.stat(executable).st_mode)
-    print(os.access(executable, os.X_OK))
-    print(os.stat(expected))
-    yield executable, expected
+    yield expected
     os.chdir(curr)
 
 
@@ -57,7 +43,7 @@ def test_cli(tmp_env, expected_file, args):
     """
     Test command line tool with option combinations
     """
-    executable, expected = tmp_env
+    expected = tmp_env
     result = sp.run([executable] + args, capture_output=True)
     print(result.stdout)
     print(result.stderr)
@@ -74,7 +60,7 @@ def test_print_help_message(tmp_env, arg):
     """
     Test command line prints help message
     """
-    executable, expected = tmp_env
+    expected = tmp_env
     result = sp.run([executable, arg], capture_output=True)
     assert result.returncode == 0
     assert help_message in result.stdout
@@ -84,7 +70,6 @@ def test_invalid_algorithm_type(tmp_env):
     """
     Test command line tool errors when given invalid argument type
     """
-    executable, _ = tmp_env
     result = sp.run([executable, '--algorithm', 'foobar'], capture_output=True)
     assert result.returncode != 0
     assert b'Invalid algorithm type: foobar' in result.stdout
@@ -95,7 +80,6 @@ def test_invalid_option(tmp_env):
     """
     Test command line tool errors when given invalid option
     """
-    executable, _ = tmp_env
     result = sp.run([executable, '--foobar'], capture_output=True)
     assert result.returncode != 0
     assert b'Invalid option: --foobar' in result.stdout

--- a/scripts/integration_test/snapshot.py
+++ b/scripts/integration_test/snapshot.py
@@ -5,7 +5,7 @@ import subprocess as sp
 from sys import argv
 
 # Config
-executable = '../../build/out/fractool/fractool'
+executable = 'fractool'
 pending_dir = 'pending'
 accepted_dir = 'expected'
 images = [

--- a/src/fractool/CMakeLists.txt
+++ b/src/fractool/CMakeLists.txt
@@ -7,5 +7,4 @@ target_link_libraries(fractool
     PRIVATE 
         ftcore 
         boost::log
-        boost::log_setup
-        boost::thread)
+        boost::log_setup)

--- a/src/fractool/CMakeLists.txt
+++ b/src/fractool/CMakeLists.txt
@@ -3,8 +3,8 @@ add_compile_definitions($<$<CONFIG:Debug>:DEBUG=1>)
 
 # Target setting
 add_executable(fractool fractool.cpp)
-target_include_directories(fractool PRIVATE
-    ${Boost_INCLUDE_DIRS})
-target_link_libraries(fractool PRIVATE
-    ftcore
-    ${Boost_LIBRARIES})
+target_link_libraries(fractool 
+    PRIVATE 
+        ftcore 
+        boost::log
+        boost::log_setup)

--- a/src/fractool/CMakeLists.txt
+++ b/src/fractool/CMakeLists.txt
@@ -7,4 +7,5 @@ target_link_libraries(fractool
     PRIVATE 
         ftcore 
         boost::log
-        boost::log_setup)
+        boost::log_setup
+        boost::thread)

--- a/src/ftcore/CMakeLists.txt
+++ b/src/ftcore/CMakeLists.txt
@@ -11,4 +11,5 @@ target_link_libraries(ftcore
         opencv::imgcodecs 
         boost::log 
         boost::log_setup
-        boost::program_options)
+        boost::program_options
+        boost::thread)

--- a/src/ftcore/CMakeLists.txt
+++ b/src/ftcore/CMakeLists.txt
@@ -5,9 +5,10 @@ add_library(ftcore
     write_image.cpp
     generate_mandelbrot.cpp
     generate_julia.cpp)
-target_include_directories(ftcore PRIVATE 
-    ${OpenCV_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS})
-target_link_libraries(ftcore PRIVATE
-    ${OpenCV_LIBS}
-    ${Boost_LIBRARIES})
+target_link_libraries(ftcore 
+    PRIVATE 
+        opencv::core 
+        opencv::imgcodecs 
+        boost::log 
+        boost::log_setup
+        boost::program_options)

--- a/src/ftcore/CMakeLists.txt
+++ b/src/ftcore/CMakeLists.txt
@@ -11,5 +11,4 @@ target_link_libraries(ftcore
         opencv::imgcodecs 
         boost::log 
         boost::log_setup
-        boost::program_options
-        boost::thread)
+        boost::program_options)


### PR DESCRIPTION
Utilize ExternalProject to download and build source code for third party libraries (opencv and boost)

CI was changed to remove the install dependencies stages since this is taken care of by CMake