### PR TITLE
Fix Cmake Build on Linux/macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,9 @@ set(Boost_USE_STATIC_LIBS ON)
 # External packages
 include(${PROJECT_SOURCE_DIR}/extern/libpng/libpng-install/lib/libpng/libpng16.cmake)
 include_directories(${PROJECT_SOURCE_DIR}/extern/libpng/libpng-install/include)
-find_package(Boost REQUIRED COMPONENTS log log_setup program_options PATHS "${PROJECT_SOURCE_DIR}/extern/boost/boost-install")
+set(BOOST_ROOT "${PROJECT_SOURCE_DIR}/extern/boost/boost-install")
+find_package(Boost REQUIRED COMPONENTS log log_setup program_options)
+include_directories(${Boost_INCLUDE_DIRS})
 
 # Source code
 add_subdirectory(src out)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ if (NOT WIN32)
     add_link_options(-pthread)
 endif()
 set(Boost_USE_STATIC_LIBS ON)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
 # External packages
 include(${PROJECT_SOURCE_DIR}/extern/libpng/libpng-install/lib/libpng/libpng16.cmake)

--- a/env/dev.sh
+++ b/env/dev.sh
@@ -1,6 +1,7 @@
 ROOT_DIR=$(pwd)
 export PATH="$PATH:$ROOT_DIR/build/test-install/bin"
 export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$ROOT_DIR/build/test-install/lib"
+export BUILD_TYPE="Debug"
 alias configure="cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$ROOT_DIR/build/test-install"
 alias build="cmake --build build"
 alias install="cmake --install build"

--- a/env/dev.sh
+++ b/env/dev.sh
@@ -1,6 +1,6 @@
-ROOT_PATH=$(pwd)
-export PATH="$PATH:$ROOT_PATH/build/test-install/bin"
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$ROOT_PATH/build/test-install/lib"
-alias configure="cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$ROOT_PATH/build/test-install"
+ROOT_DIR=$(pwd)
+export PATH="$PATH:$ROOT_DIR/build/test-install/bin"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$ROOT_DIR/build/test-install/lib"
+alias configure="cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$ROOT_DIR/build/test-install"
 alias build="cmake --build build"
 alias install="cmake --install build"


### PR DESCRIPTION
Fixing build errors on Linux/macOS caused by improper porting of windows build code to Linux/macOS side